### PR TITLE
Fix: `setup.py` dependencies and information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
-*.pyc 
+# Python
+*.pyc
+**/__pycache__/
+
+# Python distribution/packaging
+dist/
+*.egg-info/
+.eggs/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Vim
+*.swp
+
+# Temporary files
+tmp/

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>event_camera_emulation</name>
-  <version>0.0.0</version>
+  <version>0.1.1</version>
   <description>The event_camera_emulation package</description>
 
   <maintainer email="ahmed.abdelrahman@outlook.de">Ahmed Faisal Abdelrahman</maintainer>

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,34 @@
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+from setuptools import setup, find_packages
 
-d = generate_distutils_setup(
-    packages=['event_camera_emulation'],
-    package_dir={'': 'common'}
+setup(
+    name='event_camera_emulation',
+    version='0.1.0',
+    description='The event_camera_emulation package',
+    author='Ahmed Faisal Abdelrahman',
+    author_email='ahmed.abdelrahman@outlook.de',
+    maintainer='Ahmed Faisal Abdelrahman',
+    maintainer_email='ahmed.abdelrahman@outlook.de',
+    url='https://github.com/af-a/event_camera_emulation',
+    package_dir={'': 'common'},
+    packages=find_packages(include=['event_camera_emulation'], 
+                           where='common'),
+    license='MIT',
+    install_requires=[
+      'opencv-python>=4.8.1',
+      'numpy',
+      'scikit-image',
+    ],
+    setup_requires=['wheel'],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Development Status :: 4 - Beta",
+    ],
+    keywords=[
+        'Event camera',
+        'Event-based vision',
+        'Neuromorphic',
+    ],
+    zip_safe=False,
 )
-
-setup(**d)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='event_camera_emulation',
-    version='0.1.0',
+    version='0.1.1',
     description='The event_camera_emulation package',
     author='Ahmed Faisal Abdelrahman',
     author_email='ahmed.abdelrahman@outlook.de',


### PR DESCRIPTION
## Description

This PR mainly updates the `setup.py` file with the following:
* Eliminating the `catkin_pkg` package as a requirement for package installation.
* Adding a `wheel` setup dependency.
* Updating the package metadata.

In the future, this will be replaced by a `pyproject.toml`-based package installation.